### PR TITLE
GraphQL request and response headers

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,6 +130,7 @@
   "dependencies": {
     "apollo-cache-inmemory": "^1.6.2",
     "apollo-client": "^2.6.3",
+    "apollo-link": "^1.2.12",
     "apollo-link-http": "^1.5.15",
     "apollo-link-ws": "^1.0.18",
     "chart.js": "^2.7.3",

--- a/src/client/controllers/graphQLController.js
+++ b/src/client/controllers/graphQLController.js
@@ -39,7 +39,7 @@ const graphQLController = {
     });
 
     const client = new ApolloClient({
-      link: afterLink.concat(createHttpLink({ uri: reqResObj.url, headers, credentials: 'same-origin' })),
+      link: afterLink.concat(createHttpLink({ uri: reqResObj.url, headers })),
       credentials: 'include',
       cache: new InMemoryCache(),
     });

--- a/src/client/controllers/graphQLController.js
+++ b/src/client/controllers/graphQLController.js
@@ -40,7 +40,6 @@ const graphQLController = {
 
     const client = new ApolloClient({
       link: afterLink.concat(createHttpLink({ uri: reqResObj.url, headers })),
-      credentials: 'include',
       cache: new InMemoryCache(),
     });
 

--- a/src/client/controllers/graphQLController.js
+++ b/src/client/controllers/graphQLController.js
@@ -75,7 +75,6 @@ const graphQLController = {
 
   handleResponse(response, reqResObj) {
     const reqResCopy = JSON.parse(JSON.stringify(reqResObj));
-
     // TODO: Add response headers, cookies
     reqResCopy.connection = 'closed';
     reqResCopy.connectionType = 'plain';

--- a/src/client/controllers/graphQLController.js
+++ b/src/client/controllers/graphQLController.js
@@ -30,13 +30,13 @@ const graphQLController = {
     const afterLink = new ApolloLink((operation, forward) => {
       return forward(operation).map(response => {
         const context = operation.getContext();
-        console.log(context.response.headers.get('X-Powered-By'));
-        reqResObj.response.headers['Content-Length'] = context.response.headers.get('Content-Length');
-        reqResObj.response.headers['Content-Type'] = context.response.headers.get('Content-Type');
-        reqResObj.response.headers['Date'] = context.response.headers.get('Date');
-        reqResObj.response.headers['Connection'] = context.response.headers.get('Connection');
-        reqResObj.response.headers['ETag'] = context.response.headers.get('ETag');
-        console.log(reqResObj);
+        const responseHeaders = context.response.headers;
+        
+        for (let headerItem of responseHeaders.entries()) {
+          const key = headerItem[0].split('-').map(item => item[0].toUpperCase() + item.slice(1)).join('-')
+          reqResObj.response.headers[key] = headerItem[1];
+        }
+        
         return response;
       });
     });

--- a/src/client/controllers/graphQLController.js
+++ b/src/client/controllers/graphQLController.js
@@ -19,13 +19,13 @@ const graphQLController = {
 
     // TODO: Add request cookies
     const headers = {};
-    reqResObj.request.headers.forEach((item) => {
+    // added filter to take out Content-Type header because it's hard coded on front end and set by createHttpLink
+    reqResObj.request.headers.filter(item => item.key !== 'Content-Type').forEach((item) => {
       headers[item.key] = item.value;
     });
 
     const client = new ApolloClient({
-      link: createHttpLink({ uri: reqResObj.url }),
-      headers,
+      link: createHttpLink({ uri: reqResObj.url, headers }),
       credentials: 'same-origin',
       cache: new InMemoryCache(),
     });

--- a/src/client/controllers/graphQLController.js
+++ b/src/client/controllers/graphQLController.js
@@ -40,6 +40,7 @@ const graphQLController = {
 
     const client = new ApolloClient({
       link: afterLink.concat(createHttpLink({ uri: reqResObj.url, headers })),
+      credentials: 'same-origin',
       cache: new InMemoryCache(),
     });
 


### PR DESCRIPTION
Request headers weren't getting through to the intended endpoint, so the headers argument for the ApolloClient instance was moved inside of createHttpLink invocation per the [docs](https://www.apollographql.com/docs/link/links/http/).  This enabled headers to be sent to the endpoint, but the response headers were not being interpreted by the client, so ApolloLink was brought in to create an afterware that stores those headers in the reqResObj.  I would have rather not brought in another dependency ('apollo-link'), but that was the only solution I could find.