### PR TITLE
Corrected update popup rendering

### DIFF
--- a/src/assets/style/App.scss
+++ b/src/assets/style/App.scss
@@ -13,4 +13,4 @@
 @import "prompt";
 @import "websocket";
 @import "jsonPretty.scss";
-
+@import "popup.scss";

--- a/src/client/components/containers/App.tsx
+++ b/src/client/components/containers/App.tsx
@@ -4,6 +4,7 @@ import { ContentsContainer } from "./ContentsContainer";
 import { SidebarContainer } from "./SidebarContainer";
 import historyController from "../../controllers/historyController";
 import collectionsController from "../../controllers/collectionsController";
+import UpdatePopUpContainer from "./UpdatePopUpContainer";
 // import ReqResCtrl from '../../controllers/reqResController';
 
 //const { api } = window;
@@ -64,6 +65,7 @@ export class App extends React.Component<any, any> {
       <div id="app">
         <SidebarContainer />
         <ContentsContainer />
+        <UpdatePopUpContainer />
       </div>
     );
   }


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce to Scratch Project? Put an `x` in the boxes that apply. -->
- [X] Bugfix (change which fixes an issue)
- [X] New feature (change which adds functionality)
- [ ] Refactor (change which changes the codebase without affecting its external behavior)
- [ ] Non-breaking change (fix or feature that would causes existing functionality to work as expected)
- [ ] Breaking change (fix or feature that would cause existing functionality to __not__ work as expected)
## Purpose
<!--- Describe the problem or feature. Link to the issue(s) fixed by this pull request if applicable. -->
Added back the auto-update component. Originally, the app displayed a button that said 'dismiss' with no information every time the app was spun up. It was removed during this iteration of the app, since it was thought to be broken. 
## Approach
<!--- How does your change address the problem? -->
The App.tsx component now renders the UpdatePopUpContainer component, which returns a message and an option to update the app when an update is available. The 'dismiss' button no longer shows up no matter what; only when the component is set to show. 

## Screenshot(s)
<img width="1440" alt="Screen Shot 2020-09-03 at 2 22 26 PM" src="https://user-images.githubusercontent.com/63765733/92173686-ec437800-edf0-11ea-8513-1a2a3464f935.png">
