### PR TITLE
Converted UpdatePopUpContainer to functional comp, fixed conditional render

### DIFF
--- a/src/client/components/containers/UpdatePopUpContainer.jsx
+++ b/src/client/components/containers/UpdatePopUpContainer.jsx
@@ -1,64 +1,43 @@
-import React, { Component } from "react";
+import React, { useState, useEffect } from "react";
 import { connect } from "react-redux";
 
 const { api } = window;
 
 const mapDispatchToProps = (dispatch) => ({});
 
-class UpdatePopUpContainer extends Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      show: false,
-      message: "",
-    };
-    this.toggleShow = this.toggleShow.bind(this);
-    this.handleUpdateClick = this.handleUpdateClick.bind(this);
-  }
+const UpdatePopUpContainer = (props) => {
+  const [message, setMessage] = useState(null);
 
-  componentDidMount() {
+  useEffect(() => {
     api.receive("message", (e, text) => {
-      this.setState({ show: true, message: text });
+      if (text) setMessage(text);
     });
-  }
+  }, []);
 
-  toggleShow() {
-    this.setState({
-      show: !this.state.show,
-    });
-  }
-
-  handleUpdateClick() {
-    this.toggleShow();
+  const handleUpdateClick = () => {
     api.send("quit-and-install");
-  }
+    setMessage(null);
+  };
 
-  render() {
-    return this.state.show ? (
-      <div className="update_popup">
-        <p>{this.state.message}</p>
-        {this.state.message === "Update downloaded." && (
-          <>
-            <p className="updateMessage">
-              Do you want to restart and install now? <br /> (If not, will
-              auto-install on restart.)
-            </p>
-            <button
-              className="update popup-btn"
-              onClick={this.handleUpdateClick}
-            >
-              Update
-            </button>
-          </>
-        )}
-        <button className="dismiss popup-btn" onClick={this.toggleShow}>
-          Dismiss
-        </button>
-      </div>
-    ) : (
-      <></>
-    );
-  }
-}
+  return message ? (
+    <div className="update_popup">
+      <p>{message}</p>
+      {message === "Update downloaded." && (
+        <>
+          <p className="updateMessage">
+            Do you want to restart and install now? <br /> (If not, will
+            auto-install on restart.)
+          </p>
+          <button className="update popup-btn" onClick={handleUpdateClick}>
+            Update
+          </button>
+        </>
+      )}
+      <button className="dismiss popup-btn" onClick={() => setMessage(null)}>
+        Dismiss
+      </button>
+    </div>
+  ) : null;
+};
 
 export default connect(null, mapDispatchToProps)(UpdatePopUpContainer);


### PR DESCRIPTION
The popup container is now only visible when either an update is available and downloaded, or there is another message from the updater. Should not show up if there is no message from auto-updater in main process. 